### PR TITLE
fix: Typo in CSS/readme.md

### DIFF
--- a/CSS/readme.md
+++ b/CSS/readme.md
@@ -22,7 +22,7 @@ selector {
 
 ## Cascade effect in CSS
 
-What comes above can be overriden by what comes below. This only happens if both have similar specifity value or the below one has higher.
+What comes above can be overridden by what comes below. This only happens if both have similar specifity value or the below one has higher.
 
 For exp :
 ```


### PR DESCRIPTION
## Describe the changes

<!-- Provide a brief description of the purpose and goals of this pull request -->
I have rectified the misspelling of the word "overridden," which was initially written as "overriden."


<!-- List any related issues-->

## Screenshots

<!-- If applicable, include screenshots or visual representations of the changes made. -->
![Screenshot (18)](https://github.com/shubhsharma19/web-development-notes/assets/112751524/03aa7e17-6713-4b74-8bf1-f0ccb39a342b)


## Additional Notes

<!-- Include any additional notes, instructions, or context that might be helpful for the reviewer -->
