### PR TITLE
fix: Typo in CSS/readme.md

### DIFF
--- a/CSS/readme.md
+++ b/CSS/readme.md
@@ -89,10 +89,10 @@ Box model contains following things:
 - Padding: Outside the content, between content and border.
 - Content: This is the content.
 
-**Some points to remember about Box model:**
-- Padding pushes away the border from content.
+**Some points to remember about the Box model:**
 - Margin pushes away the box.
 - Border pushes away padding from the margin.
+- Padding pushes away the border from content.
 
 > Note: In box model everything gets added including borders, so we tell browser to include border as well in the box-size by giving the following property to the whole document.
 

--- a/CSS/readme.md
+++ b/CSS/readme.md
@@ -89,7 +89,7 @@ Box model contains following things:
 - Padding: Outside the content, between content and border.
 - Content: This is the content.
 
-**Some points to remember about Boxm model:**
+**Some points to remember about Box model:**
 - Padding pushes away the border from content.
 - Margin pushes away the box.
 - Border pushes away padding from the margin.


### PR DESCRIPTION
## Describe the changes

<!-- Provide a brief description of the purpose and goals of this pull request -->
I have rectified the typographical error by substituting the term "Boxm" with "Box".

## Related Issues

<!-- List any related issues-->
Closes #29 

## Screenshots

<!-- If applicable, include screenshots or visual representations of the changes made. -->

## Additional Notes

<!-- Include any additional notes, instructions, or context that might be helpful for the reviewer -->
